### PR TITLE
[feat-37] 메인 페이지 디자인 구현 완료

### DIFF
--- a/src/components/BabTemp/styles.ts
+++ b/src/components/BabTemp/styles.ts
@@ -36,7 +36,7 @@ export const ReviewTextBox = styled.div`
   margin-top: 14px;
   padding: 5px 10px;
   border-radius: 0 8px 8px 8px;
-  background-color: ${({ theme }) => theme.subColor};
+  background-color: ${({ theme }) => theme.colors.subColor};
 `;
 export const ReviewText = styled.p`
   font-size: 12px;

--- a/src/components/Board/index.tsx
+++ b/src/components/Board/index.tsx
@@ -2,6 +2,7 @@ import { BoardInfo } from '@_types/board';
 import * as S from './styles';
 import { useNavigate } from 'react-router-dom';
 import formatDate from '@_utils/formatDate';
+import { IoTimeOutline } from 'react-icons/io5';
 
 type BoardProps = {
   boardData: BoardInfo;
@@ -25,12 +26,18 @@ const Board = ({ boardData }: BoardProps) => {
         </span>
       </div>
 
-      <p>{boardData.title}</p>
-      <p>{boardData.content.length > 40 ? `${boardData.content.slice(0, 40)}...` : boardData.content}</p>
-      <p>{formatDate(boardData.eatTime)}</p>
+      <S.Title>{boardData.title}</S.Title>
+      <S.Content>
+        {boardData.content.length > 40 ? `${boardData.content.slice(0, 40)}...` : boardData.content}
+      </S.Content>
+
+      <S.TimeWrapper>
+        <IoTimeOutline size={25} />
+        <span>{formatDate(boardData.eatTime)}</span>
+      </S.TimeWrapper>
 
       <S.WriterWrapper>
-        <S.WriterImage src={boardData.writerImageUrl} alt='사용자 프로필' />
+        <S.WriterImage src={boardData.writerImageUrl} alt='' />
         <p>{boardData.writer}</p>
       </S.WriterWrapper>
     </S.Wrapper>

--- a/src/components/Board/index.tsx
+++ b/src/components/Board/index.tsx
@@ -10,6 +10,13 @@ type BoardProps = {
 
 const Board = ({ boardData }: BoardProps) => {
   const navigate = useNavigate();
+  const categoryTypeToKorean = {
+    KOREAN: '한식',
+    JAPAN: '일식',
+    CHINA: '중식',
+    WEST: '양식',
+    ALL: null,
+  };
 
   const onBoard = () => {
     navigate(`/postdetail/${boardData.id}`);
@@ -18,11 +25,13 @@ const Board = ({ boardData }: BoardProps) => {
   return (
     <S.Wrapper onClick={onBoard}>
       <S.CategoryWrapper>
-        <S.Category>{boardData.shortenedLocation}</S.Category>
-        <S.Category>{boardData.categoryType}</S.Category>
-        <S.Category>{boardData.alcohol ? '술 가능' : '술 불가'}</S.Category>
-        <S.Category>
-          {boardData.currentJoin} / {boardData.joinLimit}
+        <S.Category hasData={!!boardData.shortenedLocation}>{boardData.shortenedLocation}</S.Category>
+        <S.Category hasData={!!categoryTypeToKorean[boardData.categoryType]}>
+          {categoryTypeToKorean[boardData.categoryType]}
+        </S.Category>
+        <S.Category hasData>{boardData.alcohol ? '술 가능' : '술 불가'}</S.Category>
+        <S.Category hasData>
+          {boardData.currentJoin}명 / {boardData.joinLimit}명
         </S.Category>
       </S.CategoryWrapper>
 

--- a/src/components/Board/index.tsx
+++ b/src/components/Board/index.tsx
@@ -17,14 +17,14 @@ const Board = ({ boardData }: BoardProps) => {
 
   return (
     <S.Wrapper onClick={onBoard}>
-      <div>
-        <span>{boardData.shortenedLocation}</span>
-        <span>{boardData.categoryType}</span>
-        <span>{boardData.alcohol ? '술 가능' : '술 불가'}</span>
-        <span>
+      <S.CategoryWrapper>
+        <S.Category>{boardData.shortenedLocation}</S.Category>
+        <S.Category>{boardData.categoryType}</S.Category>
+        <S.Category>{boardData.alcohol ? '술 가능' : '술 불가'}</S.Category>
+        <S.Category>
           {boardData.currentJoin} / {boardData.joinLimit}
-        </span>
-      </div>
+        </S.Category>
+      </S.CategoryWrapper>
 
       <S.Title>{boardData.title}</S.Title>
       <S.Content>

--- a/src/components/Board/index.tsx
+++ b/src/components/Board/index.tsx
@@ -34,11 +34,11 @@ const Board = ({ boardData }: BoardProps) => {
   const isLimitedByGender = boardData.genderLimit !== 'ALL' && boardData.genderLimit !== userInfo.genderType;
 
   const isLimitedByAge =
-    (boardData.ageLimit.up && boardData.ageLimit.up < calculateAge(userInfo.birthYear)) ||
-    (boardData.ageLimit.down && boardData.ageLimit.down > calculateAge(userInfo.birthYear));
+    !!(boardData.ageLimit.up && boardData.ageLimit.up < calculateAge(userInfo.birthYear)) ||
+    !!(boardData.ageLimit.down && boardData.ageLimit.down > calculateAge(userInfo.birthYear));
 
   return (
-    <S.Wrapper onClick={onBoard}>
+    <S.Container>
       {boardData.fix ? (
         <S.BlockContainer>확정 완료</S.BlockContainer>
       ) : isLimitedByGender ? (
@@ -47,32 +47,34 @@ const Board = ({ boardData }: BoardProps) => {
         <S.BlockContainer>나이 제한</S.BlockContainer>
       ) : null}
 
-      <S.CategoryWrapper>
-        <S.Category hasData={!!boardData.shortenedLocation}>{boardData.shortenedLocation}</S.Category>
-        <S.Category hasData={!!categoryTypeToKorean[boardData.categoryType]}>
-          {categoryTypeToKorean[boardData.categoryType]}
-        </S.Category>
-        <S.Category>{boardData.alcohol ? '술 가능' : '술 불가'}</S.Category>
-        <S.Category>
-          {boardData.currentJoin}명 / {boardData.joinLimit}명
-        </S.Category>
-      </S.CategoryWrapper>
+      <S.Wrapper isLimit={boardData.fix || isLimitedByGender || isLimitedByAge} onClick={onBoard}>
+        <S.CategoryWrapper>
+          <S.Category hasData={!!boardData.shortenedLocation}>{boardData.shortenedLocation}</S.Category>
+          <S.Category hasData={!!categoryTypeToKorean[boardData.categoryType]}>
+            {categoryTypeToKorean[boardData.categoryType]}
+          </S.Category>
+          <S.Category>{boardData.alcohol ? '술 가능' : '술 불가'}</S.Category>
+          <S.Category>
+            {boardData.currentJoin}명 / {boardData.joinLimit}명
+          </S.Category>
+        </S.CategoryWrapper>
 
-      <S.Title>{boardData.title}</S.Title>
-      <S.Content>
-        {boardData.content.length > 40 ? `${boardData.content.slice(0, 40)}...` : boardData.content}
-      </S.Content>
+        <S.Title>{boardData.title}</S.Title>
+        <S.Content>
+          {boardData.content.length > 40 ? `${boardData.content.slice(0, 40)}...` : boardData.content}
+        </S.Content>
 
-      <S.TimeWrapper>
-        <IoTimeOutline size={25} />
-        <span>{formatDate(boardData.eatTime)}</span>
-      </S.TimeWrapper>
+        <S.TimeWrapper>
+          <IoTimeOutline size={25} />
+          <span>{formatDate(boardData.eatTime)}</span>
+        </S.TimeWrapper>
 
-      <S.WriterWrapper>
-        <S.WriterImage src={boardData.writerImageUrl} alt='' />
-        <p>{boardData.writer}</p>
-      </S.WriterWrapper>
-    </S.Wrapper>
+        <S.WriterWrapper>
+          <S.WriterImage src={boardData.writerImageUrl} alt='' />
+          <p>{boardData.writer}</p>
+        </S.WriterWrapper>
+      </S.Wrapper>
+    </S.Container>
   );
 };
 

--- a/src/components/Board/index.tsx
+++ b/src/components/Board/index.tsx
@@ -29,10 +29,10 @@ const Board = ({ boardData }: BoardProps) => {
       <p>{boardData.content.length > 40 ? `${boardData.content.slice(0, 40)}...` : boardData.content}</p>
       <p>{formatDate(boardData.eatTime)}</p>
 
-      <div>
-        <img src={boardData.writerImageUrl} alt='사용자 프로필' />
+      <S.WriterWrapper>
+        <S.WriterImage src={boardData.writerImageUrl} alt='사용자 프로필' />
         <p>{boardData.writer}</p>
-      </div>
+      </S.WriterWrapper>
     </S.Wrapper>
   );
 };

--- a/src/components/Board/index.tsx
+++ b/src/components/Board/index.tsx
@@ -37,17 +37,17 @@ const Board = ({ boardData }: BoardProps) => {
     !!(boardData.ageLimit.up && boardData.ageLimit.up < calculateAge(userInfo.birthYear)) ||
     !!(boardData.ageLimit.down && boardData.ageLimit.down > calculateAge(userInfo.birthYear));
 
+  const isLimit = boardData.fix || isLimitedByGender || isLimitedByAge;
+
   return (
     <S.Container>
-      {boardData.fix ? (
-        <S.BlockContainer>확정 완료</S.BlockContainer>
-      ) : isLimitedByGender ? (
-        <S.BlockContainer>성별 제한</S.BlockContainer>
-      ) : isLimitedByAge ? (
-        <S.BlockContainer>나이 제한</S.BlockContainer>
+      {isLimit ? (
+        <S.BlockContainer>
+          {boardData.fix ? '확정 완료' : isLimitedByGender ? '성별 제한' : isLimitedByAge ? '나이 제한' : null}
+        </S.BlockContainer>
       ) : null}
 
-      <S.Wrapper isLimit={boardData.fix || isLimitedByGender || isLimitedByAge} onClick={onBoard}>
+      <S.Wrapper isLimit={isLimit} onClick={onBoard}>
         <S.CategoryWrapper>
           <S.Category hasData={!!boardData.shortenedLocation}>{boardData.shortenedLocation}</S.Category>
           <S.Category hasData={!!categoryTypeToKorean[boardData.categoryType]}>

--- a/src/components/Board/index.tsx
+++ b/src/components/Board/index.tsx
@@ -3,12 +3,15 @@ import * as S from './styles';
 import { useNavigate } from 'react-router-dom';
 import formatDate from '@_utils/formatDate';
 import { IoTimeOutline } from 'react-icons/io5';
+import { useRecoilValue } from 'recoil';
+import { userState } from '@_recoil/atoms/user';
 
 type BoardProps = {
   boardData: BoardInfo;
 };
 
 const Board = ({ boardData }: BoardProps) => {
+  const userInfo = useRecoilValue(userState);
   const navigate = useNavigate();
   const categoryTypeToKorean = {
     KOREAN: '한식',
@@ -18,19 +21,39 @@ const Board = ({ boardData }: BoardProps) => {
     ALL: null,
   };
 
+  const calculateAge = (birthYear: number) => {
+    const currentYear = new Date().getFullYear();
+
+    return currentYear - birthYear + 1;
+  };
+
   const onBoard = () => {
     navigate(`/postdetail/${boardData.id}`);
   };
 
+  const isLimitedByGender = boardData.genderLimit !== 'ALL' && boardData.genderLimit !== userInfo.genderType;
+
+  const isLimitedByAge =
+    (boardData.ageLimit.up && boardData.ageLimit.up < calculateAge(userInfo.birthYear)) ||
+    (boardData.ageLimit.down && boardData.ageLimit.down > calculateAge(userInfo.birthYear));
+
   return (
     <S.Wrapper onClick={onBoard}>
+      {boardData.fix ? (
+        <S.BlockContainer>확정 완료</S.BlockContainer>
+      ) : isLimitedByGender ? (
+        <S.BlockContainer>성별 제한</S.BlockContainer>
+      ) : isLimitedByAge ? (
+        <S.BlockContainer>나이 제한</S.BlockContainer>
+      ) : null}
+
       <S.CategoryWrapper>
         <S.Category hasData={!!boardData.shortenedLocation}>{boardData.shortenedLocation}</S.Category>
         <S.Category hasData={!!categoryTypeToKorean[boardData.categoryType]}>
           {categoryTypeToKorean[boardData.categoryType]}
         </S.Category>
-        <S.Category hasData>{boardData.alcohol ? '술 가능' : '술 불가'}</S.Category>
-        <S.Category hasData>
+        <S.Category>{boardData.alcohol ? '술 가능' : '술 불가'}</S.Category>
+        <S.Category>
           {boardData.currentJoin}명 / {boardData.joinLimit}명
         </S.Category>
       </S.CategoryWrapper>

--- a/src/components/Board/styles.ts
+++ b/src/components/Board/styles.ts
@@ -4,8 +4,22 @@ export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   padding: 20px;
-  border-top: 4px solid ${({ theme }) => `${theme.colors.mainColor}80`};
+  border-top: 4px solid ${({ theme }) => `${theme.colors.mainColor}50`};
   cursor: pointer;
+`;
+
+export const CategoryWrapper = styled.div`
+  display: flex;
+  gap: 10px;
+  margin-bottom: 7px;
+`;
+
+export const Category = styled.div`
+  padding: 1px 20px;
+  border-radius: 10px;
+  background-color: ${({ theme }) => theme.colors.mainColor};
+  color: white;
+  font-size: 0.8em;
 `;
 
 export const Title = styled.p`

--- a/src/components/Board/styles.ts
+++ b/src/components/Board/styles.ts
@@ -14,7 +14,8 @@ export const CategoryWrapper = styled.div`
   margin-bottom: 7px;
 `;
 
-export const Category = styled.div`
+export const Category = styled.div<{ hasData: boolean }>`
+  display: ${({ hasData }) => (hasData ? 'block' : 'none')};
   padding: 1px 20px;
   border-radius: 10px;
   background-color: ${({ theme }) => theme.colors.mainColor};

--- a/src/components/Board/styles.ts
+++ b/src/components/Board/styles.ts
@@ -1,6 +1,47 @@
 import { styled } from 'styled-components';
 
 export const Wrapper = styled.div`
-  padding: 20px 15px;
-  border-bottom: 5px solid black;
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  border-top: 4px solid ${({ theme }) => `${theme.colors.mainColor}80`};
+  cursor: pointer;
+`;
+
+export const Title = styled.p`
+  font-size: 1.3em;
+  font-family: 'Pretendard-SemiBold';
+  margin-bottom: 5px;
+`;
+
+export const Content = styled.p`
+  margin-bottom: 20px;
+  color: rgba(0, 0, 0, 0.8);
+`;
+
+export const TimeWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  margin-bottom: 3px;
+
+  & > span {
+    color: rgba(0, 0, 0, 0.6);
+  }
+`;
+
+export const WriterWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: rgba(0, 0, 0, 0.6);
+`;
+
+export const WriterImage = styled.img`
+  width: 21px;
+  height: 21px;
+  margin-left: 2px;
+  border: 1px solid black;
+  border-radius: 50%;
+  object-fit: cover;
 `;

--- a/src/components/Board/styles.ts
+++ b/src/components/Board/styles.ts
@@ -1,12 +1,10 @@
 import { styled } from 'styled-components';
 
-export const Wrapper = styled.div`
+export const Container = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: 20px;
   border-top: 4px solid ${({ theme }) => `${theme.colors.mainColor}50`};
-  cursor: pointer;
 `;
 
 export const BlockContainer = styled.div`
@@ -18,7 +16,7 @@ export const BlockContainer = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: rgba(0, 0, 0, 0.3);
   color: ${({ theme }) => theme.colors.mainColor};
   font-family: 'Pretendard-SemiBold';
   font-size: 3em;
@@ -27,6 +25,17 @@ export const BlockContainer = styled.div`
     0px 1px rgb(0, 0, 0),
     1px 0px rgb(0, 0, 0),
     0px -1px rgb(0, 0, 0);
+`;
+
+export const Wrapper = styled.div<{ isLimit: boolean }>`
+  padding: 20px;
+  filter: ${({ isLimit }) => (isLimit ? 'blur(2px) brightness(60%)' : 'none')};
+  transition: 0.3s ease;
+  cursor: pointer;
+
+  &:hover {
+    transform: ${({ isLimit }) => (isLimit ? 'none' : 'scale(1.02)')};
+  }
 `;
 
 export const CategoryWrapper = styled.div`
@@ -66,6 +75,7 @@ export const TimeWrapper = styled.div`
   margin-bottom: 3px;
 
   & > span {
+    font-size: 0.85em;
     color: rgba(0, 0, 0, 0.6);
   }
 `;
@@ -74,6 +84,7 @@ export const WriterWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 5px;
+  font-size: 0.85em;
   color: rgba(0, 0, 0, 0.6);
 `;
 

--- a/src/components/Board/styles.ts
+++ b/src/components/Board/styles.ts
@@ -1,11 +1,32 @@
 import { styled } from 'styled-components';
 
 export const Wrapper = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   padding: 20px;
   border-top: 4px solid ${({ theme }) => `${theme.colors.mainColor}50`};
   cursor: pointer;
+`;
+
+export const BlockContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+  color: ${({ theme }) => theme.colors.mainColor};
+  font-family: 'Pretendard-SemiBold';
+  font-size: 3em;
+  text-shadow:
+    -1px 0px rgb(0, 0, 0),
+    0px 1px rgb(0, 0, 0),
+    1px 0px rgb(0, 0, 0),
+    0px -1px rgb(0, 0, 0);
 `;
 
 export const CategoryWrapper = styled.div`
@@ -14,7 +35,7 @@ export const CategoryWrapper = styled.div`
   margin-bottom: 7px;
 `;
 
-export const Category = styled.div<{ hasData: boolean }>`
+export const Category = styled.div<{ hasData?: boolean }>`
   display: ${({ hasData }) => (hasData ? 'block' : 'none')};
   padding: 1px 20px;
   border-radius: 10px;
@@ -22,6 +43,10 @@ export const Category = styled.div<{ hasData: boolean }>`
   color: white;
   font-size: 0.8em;
 `;
+
+Category.defaultProps = {
+  hasData: true,
+};
 
 export const Title = styled.p`
   font-size: 1.3em;

--- a/src/components/CommentInput/styles.ts
+++ b/src/components/CommentInput/styles.ts
@@ -34,7 +34,7 @@ export const CommentInput = styled.textarea`
     font-family: 'Pretendard-ExtraLight';
   }
   &:focus {
-    border: 1px solid ${({ theme }) => theme.mainColor};
+    border: 1px solid ${({ theme }) => theme.colors.mainColor};
   }
 `;
 export const SubmitButton = styled.span`
@@ -44,7 +44,7 @@ export const SubmitButton = styled.span`
   margin-top: 18px;
   margin-right: 10px;
   border-radius: 5px;
-  background-color: ${({ theme }) => theme.subColor};
+  background-color: ${({ theme }) => theme.colors.subColor};
   color: #fff;
   cursor: pointer;
 `;

--- a/src/components/KakaoMapModal/styles.ts
+++ b/src/components/KakaoMapModal/styles.ts
@@ -49,7 +49,7 @@ export const MarkerContent = styled.p`
 export const ConfirmBtn = styled.button`
   width: 100%;
   height: 50px;
-  background-color: ${({ theme }) => theme.subColor};
+  background-color: ${({ theme }) => theme.colors.subColor};
   color: #fff;
   border-radius: 15px;
   margin-top: 10px;

--- a/src/components/ProfileInfo/styles.ts
+++ b/src/components/ProfileInfo/styles.ts
@@ -56,13 +56,13 @@ export const CancleWrap = styled.div`
   margin-left: 10px;
   width: 66px;
   height: 36px;
-  border: 1px solid ${({ theme }) => theme.blackColor};
+  border: 1px solid ${({ theme }) => theme.colors.blackColor};
   border-radius: 8px;
   cursor: pointer;
 `;
 export const CancleText = styled.p`
   font-size: 12px;
-  color: ${({ theme }) => theme.blackColor};
+  color: ${({ theme }) => theme.colors.blackColor};
 `;
 export const EditWrap = styled.div`
   display: flex;
@@ -72,13 +72,13 @@ export const EditWrap = styled.div`
   margin-left: 10px;
   width: 66px;
   height: 36px;
-  border: 1px solid ${({ theme }) => theme.mainColor};
+  border: 1px solid ${({ theme }) => theme.colors.mainColor};
   border-radius: 8px;
   cursor: pointer;
 `;
 export const EditText = styled.p`
   font-size: 12px;
-  color: ${({ theme }) => theme.mainColor};
+  color: ${({ theme }) => theme.colors.mainColor};
 `;
 export const EditingWrap = styled.div`
   width: 100%;
@@ -103,6 +103,6 @@ export const EditingInput = styled.input`
     font-family: 'Pretendard-ExtraLight';
   }
   &:focus {
-    border: 1px solid ${({ theme }) => theme.mainColor};
+    border: 1px solid ${({ theme }) => theme.colors.mainColor};
   }
 `;

--- a/src/components/SelectOption/styles.ts
+++ b/src/components/SelectOption/styles.ts
@@ -10,7 +10,7 @@ export const SelectOptionContainer = styled.div`
     margin-bottom: 15px;
     font-size: 16px;
     font-family: 'Pretendard-SemiBold';
-    color: ${({ theme }) => theme.blackColor};
+    color: ${({ theme }) => theme.colors.blackColor};
   }
   input {
     width: 100%;
@@ -25,7 +25,7 @@ export const SelectOptionContainer = styled.div`
       font-family: 'Pretendard-ExtraLight';
     }
     &:focus {
-      border: 1px solid ${({ theme }) => theme.mainColor};
+      border: 1px solid ${({ theme }) => theme.colors.mainColor};
     }
   }
   select {
@@ -58,7 +58,7 @@ export const TimeInput = styled.input``;
 export const StoreNameWrap = styled.div``;
 export const StoreName = styled.p`
   margin-top: 20px;
-  color: ${({ theme }) => theme.mainColor};
+  color: ${({ theme }) => theme.colors.mainColor};
 `;
 export const StoreBtn = styled.button`
   border: 0.1px solid black;
@@ -90,7 +90,7 @@ export const AlcholInput = styled.input`
   height: 0;
   width: 0;
   &:checked + span {
-    background-color: ${({ theme }) => theme.mainColor};
+    background-color: ${({ theme }) => theme.colors.mainColor};
   }
   &:checked + span::after {
     display: block;
@@ -138,7 +138,7 @@ export const AgeLimitInput = styled.input`
   height: 0;
   width: 0;
   &:checked + span {
-    background-color: ${({ theme }) => theme.mainColor};
+    background-color: ${({ theme }) => theme.colors.mainColor};
   }
   &:checked + span::after {
     display: block;
@@ -186,7 +186,7 @@ export const GenderInput = styled.input`
   height: 0;
   width: 0;
   &:checked + span {
-    background-color: ${({ theme }) => theme.mainColor};
+    background-color: ${({ theme }) => theme.colors.mainColor};
   }
   &:checked + span::after {
     display: block;
@@ -219,7 +219,7 @@ export const NextBtnWrap = styled.div`
 export const NextBtn = styled.button`
   padding: 6px 30px;
   border-radius: 10px;
-  background-color: ${({ theme }) => theme.subColor};
+  background-color: ${({ theme }) => theme.colors.subColor};
   color: white;
   width: 100%;
   cursor: pointer;

--- a/src/components/SideBar/styles.ts
+++ b/src/components/SideBar/styles.ts
@@ -34,7 +34,7 @@ export const CloseBtn = styled.img`
   cursor: pointer;
 `;
 export const Profile = styled.div`
-  border-bottom: 0.1px solid ${({ theme }) => theme.subColor};
+  border-bottom: 0.1px solid ${({ theme }) => theme.colors.subColor};
   padding-bottom: 30px;
   margin-top: 30px;
   display: flex;

--- a/src/components/common/Header/styles.ts
+++ b/src/components/common/Header/styles.ts
@@ -34,7 +34,7 @@ export const HeaderLogin = styled.div`
   justify-content: center;
   align-items: center;
   font-family: 'Pretendard-Bold';
-  background-color: ${({ theme }) => theme.mainColor};
+  background-color: ${({ theme }) => theme.colors.mainColor};
   color: white;
   border-radius: 10px;
 `;

--- a/src/components/common/Input/styles.ts
+++ b/src/components/common/Input/styles.ts
@@ -14,7 +14,7 @@ export const ElInput = styled.input`
     font-family: 'Pretendard-ExtraLight';
   }
   &:focus {
-    border: 1px solid ${({ theme }) => theme.mainColor};
+    border: 1px solid ${({ theme }) => theme.colors.mainColor};
   }
 `;
 export const Label = styled.label`

--- a/src/components/common/Spinner/styles.ts
+++ b/src/components/common/Spinner/styles.ts
@@ -12,7 +12,7 @@ export const Spin = styled.span`
   width: 48px;
   height: 48px;
   border: 5px solid #fff;
-  border-bottom-color: ${({ theme }) => theme.mainColor};
+  border-bottom-color: ${({ theme }) => theme.colors.mainColor};
   border-radius: 50%;
   display: inline-block;
   box-sizing: border-box;

--- a/src/components/common/Textarea/styles.ts
+++ b/src/components/common/Textarea/styles.ts
@@ -18,7 +18,7 @@ export const ElTextarea = styled.textarea`
     font-family: 'Pretendard-ExtraLight';
   }
   &:focus {
-    border: 1px solid ${({ theme }) => theme.mainColor};
+    border: 1px solid ${({ theme }) => theme.colors.mainColor};
   }
 `;
 export const Label = styled.label`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,11 +4,11 @@ import { ThemeProvider } from 'styled-components';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import GlobalStyle from '@_style/global';
-import theme from '@_style/theme';
 import '@_assets/fonts/font.css';
 import App from './App';
 import RecoilNexus from 'recoil-nexus';
 import { BrowserRouter } from 'react-router-dom';
+import { theme } from '@_style/theme';
 
 async function enableMocking() {
   if (!process.env.REACT_APP_USE_MOCK) return;

--- a/src/mocks/api/data/boardData.ts
+++ b/src/mocks/api/data/boardData.ts
@@ -16,7 +16,6 @@ export const getBoardData = () => {
       currentJoin: 2,
       joinLimit: 4,
       ageLimit: {
-        isLimit: true,
         up: 30,
         down: 25,
       },
@@ -37,7 +36,6 @@ export const getBoardData = () => {
       currentJoin: 4,
       joinLimit: 4,
       ageLimit: {
-        isLimit: false,
         up: null,
         down: null,
       },
@@ -58,7 +56,6 @@ export const getBoardData = () => {
       currentJoin: 0,
       joinLimit: 4,
       ageLimit: {
-        isLimit: true,
         up: 25,
         down: 20,
       },
@@ -82,7 +79,6 @@ export const getBoardData = () => {
       currentJoin: i % 5,
       joinLimit: 5,
       ageLimit: {
-        isLimit: i % 2 ? true : false,
         up: i % 2 ? 40 : null,
         down: i % 2 ? 22 : null,
       },

--- a/src/pages/CreatePostContent/styles.ts
+++ b/src/pages/CreatePostContent/styles.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const CreateContentContainer = styled.div`
   p {
-    color: ${({ theme }) => theme.blackColor};
+    color: ${({ theme }) => theme.colors.blackColor};
   }
   input {
     width: 100%;
@@ -17,7 +17,7 @@ export const CreateContentContainer = styled.div`
       font-family: 'Pretendard-ExtraLight';
     }
     &:focus {
-      border: 1px solid ${({ theme }) => theme.mainColor};
+      border: 1px solid ${({ theme }) => theme.colors.mainColor};
     }
   }
 `;
@@ -78,7 +78,7 @@ export const ContentInput = styled.textarea`
     font-family: 'Pretendard-ExtraLight';
   }
   &:focus {
-    border: 1px solid ${({ theme }) => theme.mainColor};
+    border: 1px solid ${({ theme }) => theme.colors.mainColor};
   }
 `;
 export const Link = styled.div`
@@ -110,6 +110,6 @@ export const PrevBtn = styled.button`
   border: 0.1px solid black;
 `;
 export const registrationBtn = styled.button`
-  background-color: ${({ theme }) => theme.subColor};
+  background-color: ${({ theme }) => theme.colors.subColor};
   color: white;
 `;

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -1,16 +1,19 @@
+import { DefaultTheme } from 'styled-components';
+
 const size = {
   mobileL: '576px',
   tablet: '768px',
   laptop: '992px',
 };
 
-const theme = {
-  mainColor: '#f39c12',
-  subColor: '#30336b',
-  blackColor: '#222',
+export const theme: DefaultTheme = {
+  colors: {
+    mainColor: '#f39c12',
+    subColor: '#30336b',
+    blackColor: '#222',
+  },
+
   mobileL: `(min-width: ${size.mobileL})`,
   tablet: `(min-width: ${size.tablet})`,
   laptop: `(min-width: ${size.laptop})`,
 };
-
-export default theme;

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -11,7 +11,6 @@ export type BoardInfo = {
   currentJoin: number;
   joinLimit: number;
   ageLimit: {
-    isLimit: boolean;
     up: number | null;
     down: number | null;
   };

--- a/src/types/styled.d.ts
+++ b/src/types/styled.d.ts
@@ -1,0 +1,14 @@
+import 'styled-components';
+
+declare module 'styled-components' {
+  export interface DefaultTheme {
+    colors: {
+      mainColor: string;
+      subColor: string;
+      blackColor: string;
+    };
+    mobileL: string;
+    tablet: string;
+    laptop: string;
+  }
+}


### PR DESCRIPTION
메인 페이지를 디자인 하였습니다.

상단 카테고리에는 `주소, 식사 종류, 음주 여부, 현재 인원 / 총 인원` 으로 구성되어 있고, 값이 없다면 표시되지 않도록 하였습니다.
중간에는 `제목 및 내용`이 들어가고, 하단에는 `약속 시간과 작성자` 가 위치해 있습니다.

내용은 일정 크기를 넘어가면 뒷부분은 자르게 구현하였습니다.

또한, 약속이 픽스 됐거나, 나이, 성별 제한이 걸린다면 따로 표시하였습니다.
(제한이 걸리면 그 페이지로 이동하지 못하게 하려고 했으나, 보는 편이 나을 것 같아서 막지는 않았습니다. 
안의 내용에서도 제한이 된 것을 표시해주시면 감사하겠습니다.)

---

### 그 밖에
styled-components의 타입을 설정하고 구조를 일부 변경하였습니다.
```js
theme = {
  colors: {
    mainColor: ...,
    ...
  },
  mobileL: ...
  ...
}
```
이렇게 구조를 변경하였습니다.

따라서 기존에 `${({ theme }) => theme.mainColor}` 로 작성하셨던 것을 `${({ theme }) => theme.colors.mainColor}` 로 사용하시면 됩니다.
추가로 이제 자동완성도 가능할 것입니다 !

---

### 해야할 일
- react-query로 데이터 관리하기
- 무한 스크롤 구현하기

---

- close #37 